### PR TITLE
Enable consistent code formatting

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Style checking
+
+on: [push, pull_request]
+
+jobs:
+  stylua:
+    name: stylua
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: JohnnyMorganz/stylua-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          # CLI arguments
+          args: --color always --check lua/

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,4 @@
+indent_width = 2
+indent_type = "Spaces"
+quote_style = "AutoPreferSingle"
+column_width = 80

--- a/lua/tshjkl/nav.lua
+++ b/lua/tshjkl/nav.lua
@@ -16,13 +16,17 @@ M.op = op
 local named_sib_ops = {
   [op.first] = function(node)
     local parent = node:parent()
-    if parent == nil then return end
+    if parent == nil then
+      return
+    end
 
     return parent:named_child(0)
   end,
   [op.last] = function(node)
     local parent = node:parent()
-    if parent == nil then return end
+    if parent == nil then
+      return
+    end
 
     return parent:named_child(parent:named_child_count() - 1)
   end,
@@ -31,20 +35,24 @@ local named_sib_ops = {
   end,
   [op.prev] = function(node)
     return node:prev_named_sibling()
-  end
+  end,
 }
 
 ---@type OpTable
 local unnamed_sib_ops = {
-  [op.first] = function (node)
+  [op.first] = function(node)
     local parent = node:parent()
-    if parent == nil then return end
+    if parent == nil then
+      return
+    end
 
     return parent:child(0)
   end,
   [op.last] = function(node)
     local parent = node:parent()
-    if parent == nil then return end
+    if parent == nil then
+      return
+    end
 
     return parent:child(parent:child_count() - 1)
   end,
@@ -53,13 +61,17 @@ local unnamed_sib_ops = {
   end,
   [op.prev] = function(node)
     return node:prev_sibling()
-  end
+  end,
 }
 
 local named = true
 ---@param named_ boolean
-function M.set_named_mode(named_) named = named_ end
-function M.is_named_mode() return named end
+function M.set_named_mode(named_)
+  named = named_
+end
+function M.is_named_mode()
+  return named
+end
 
 ---@param node TSNode
 ---@param op_ Op
@@ -92,4 +104,3 @@ function M.parent(node)
 end
 
 return M
-

--- a/lua/tshjkl/trail.lua
+++ b/lua/tshjkl/trail.lua
@@ -9,19 +9,23 @@ local M = {}
 
 function M.start()
   local node = vim.treesitter.get_node()
-  if node == nil then return end
+  if node == nil then
+    return
+  end
 
   ---@type Node
   local current = { node = node }
 
   local function from_child_to_parent()
     local parent = nav.parent(current.node)
-    if parent == nil then return end
+    if parent == nil then
+      return
+    end
 
     if current.parent == nil or current.parent.node ~= node then
       current.parent = {
         node = parent,
-        child = current
+        child = current,
       }
     end
 
@@ -33,11 +37,13 @@ function M.start()
     if current.child == nil then
       local child = nav.child(current.node)
 
-      if child == nil then return end
+      if child == nil then
+        return
+      end
 
       current.child = {
         node = child,
-        parent = current
+        parent = current,
       }
     end
 
@@ -48,10 +54,12 @@ function M.start()
   ---@param op Op
   local function from_sib_to_sib(op)
     local sibling = nav.sibling(current.node, op)
-    if sibling == nil then return end
+    if sibling == nil then
+      return
+    end
 
     current = {
-      node = sibling
+      node = sibling,
     }
 
     return current.node
@@ -81,9 +89,11 @@ function M.start()
     from_child_to_parent = from_child_to_parent,
     from_parent_to_child = from_parent_to_child,
     from_sib_to_sib = from_sib_to_sib,
-    current = function() return current.node end,
+    current = function()
+      return current.node
+    end,
     move_innermost = move_innermost,
-    move_outermost = move_outermost
+    move_outermost = move_outermost,
   }
 end
 


### PR DESCRIPTION
How would you feel about having a common format for the code in this plugin?

Benefits:
- reduces the chance of merge conflicts that are caused by formatting differences
- the code style is very easy to follow (probably enabled by default when using https://github.com/stevearc/conform.nvim). The default is to format on save so you have to do literally nothing.

Drawbacks:
- developers need to install conform or use stylua on the command line
- the formatter is not that configurable (can also be a benefit if you have no problems with the style)

Here's the description from one of the commits in this PR:

> Code formatting can help new contributors adapt to the coding standard in the project.
> 
> The default in LazyVim (which I use) is to have autoformatting on, although I'm not sure what is the exact plugin that configures this.
> 
> I looked around for examples of how projects normally configure stylua, and came across the one from the widely used telescope from 2021-07-23:
> https://github.com/nvim-telescope/telescope.nvim/pull/1040