### PR TITLE
docs: update readme to mention select_current_node_overrides setting

### DIFF
--- a/lua/tshjkl/init.lua
+++ b/lua/tshjkl/init.lua
@@ -4,7 +4,7 @@ local nav = require('tshjkl.nav')
 local M = {}
 
 local default_config = {
-  -- false to highlight only.
+  -- false to highlight only. Note that enabling this will hide the highlighting of child nodes
   select_current_node = true,
   keymaps = {
     toggle = '<M-v>',

--- a/lua/tshjkl/init.lua
+++ b/lua/tshjkl/init.lua
@@ -4,7 +4,8 @@ local nav = require('tshjkl.nav')
 local M = {}
 
 local default_config = {
-  select_current_node = true, -- false to highlight only
+  -- false to highlight only.
+  select_current_node = true,
   keymaps = {
     toggle = '<M-v>',
     toggle_outer = '<S-M-v>',

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ You can override the [default config](lua/tshjkl/init.lua) with lazy `opts`:
 {
   'gsuuon/tshjkl.nvim',
   opts = {
+    -- false to highlight only.
+    select_current_node = true,
     keymaps = {
       toggle = '<leader>ct',
     },

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ You can override the [default config](lua/tshjkl/init.lua) with lazy `opts`:
 {
   'gsuuon/tshjkl.nvim',
   opts = {
-    -- false to highlight only.
+    -- false to highlight only. Note that enabling this will hide the highlighting of child nodes
     select_current_node = true,
     keymaps = {
       toggle = '<leader>ct',


### PR DESCRIPTION
I noticed this was missing from the example in the readme.

---

I also noticed that custom highlights are not applied for me when I have the node automatically selected. The "selected" type of text appeared instead.

Here is an example of how it works when `false` (the node is highlighted with a custom color). This is what I was looking for.
<img width="431" alt="image" src="https://github.com/gsuuon/tshjkl.nvim/assets/300791/fd592a10-d540-4381-9498-4f2ee11afc8d">

Here's how it works when `true` (the node is highlighted with my default "selected" color). This is unexpected.
<img width="405" alt="image" src="https://github.com/gsuuon/tshjkl.nvim/assets/300791/6f5574f8-90c6-4fc9-8689-e2ab2c08f342">
