### PR TITLE
Improvements to types and testing

### DIFF
--- a/lua/tshjkl/nav.lua
+++ b/lua/tshjkl/nav.lua
@@ -22,6 +22,7 @@ local named_sib_ops = {
 
     return parent:named_child(0)
   end,
+
   [op.last] = function(node)
     local parent = node:parent()
     if parent == nil then
@@ -30,9 +31,11 @@ local named_sib_ops = {
 
     return parent:named_child(parent:named_child_count() - 1)
   end,
+
   [op.next] = function(node)
     return node:next_named_sibling()
   end,
+
   [op.prev] = function(node)
     return node:prev_named_sibling()
   end,
@@ -48,6 +51,7 @@ local unnamed_sib_ops = {
 
     return parent:child(0)
   end,
+
   [op.last] = function(node)
     local parent = node:parent()
     if parent == nil then
@@ -56,19 +60,24 @@ local unnamed_sib_ops = {
 
     return parent:child(parent:child_count() - 1)
   end,
+
   [op.next] = function(node)
     return node:next_sibling()
   end,
+
   [op.prev] = function(node)
     return node:prev_sibling()
   end,
 }
 
 local named = true
+
 ---@param named_ boolean
+---@return nil
 function M.set_named_mode(named_)
   named = named_
 end
+
 function M.is_named_mode()
   return named
 end
@@ -83,6 +92,7 @@ function M.sibling(node, op_)
   end
 end
 
+---@param node TSNode
 function M.child(node)
   if named then
     return node:named_child(0)
@@ -91,6 +101,7 @@ function M.child(node)
   end
 end
 
+---@param node TSNode
 function M.parent(node)
   if named then
     local parent_ = node:parent()

--- a/lua/tshjkl/trail.lua
+++ b/lua/tshjkl/trail.lua
@@ -7,6 +7,15 @@ local M = {}
 ---@field parent? Node
 ---@field child? Node
 
+---@class Trail
+---@field from_child_to_parent fun(): TSNode | nil
+---@field from_parent_to_child fun(): TSNode | nil
+---@field from_sib_to_sib fun(op: Op): TSNode | nil
+---@field current fun(): TSNode | nil
+---@field move_innermost fun(): TSNode | nil
+---@field move_outermost fun(): TSNode | nil
+
+---@return Trail | nil
 function M.start()
   local node = vim.treesitter.get_node()
   if node == nil then
@@ -16,6 +25,7 @@ function M.start()
   ---@type Node
   local current = { node = node }
 
+  ---@return TSNode | nil
   local function from_child_to_parent()
     local parent = nav.parent(current.node)
     if parent == nil then
@@ -33,6 +43,7 @@ function M.start()
     return current.node
   end
 
+  ---@return TSNode | nil
   local function from_parent_to_child()
     if current.child == nil then
       local child = nav.child(current.node)
@@ -52,6 +63,7 @@ function M.start()
   end
 
   ---@param op Op
+  ---@return TSNode | nil
   local function from_sib_to_sib(op)
     local sibling = nav.sibling(current.node, op)
     if sibling == nil then
@@ -65,6 +77,7 @@ function M.start()
     return current.node
   end
 
+  ---@return TSNode | nil
   local function move_outermost()
     local parent = nav.parent(current.node)
 
@@ -77,6 +90,7 @@ function M.start()
     return from_parent_to_child()
   end
 
+  ---@return TSNode | nil
   local function move_innermost()
     while current.child ~= nil do
       current = current.child


### PR DESCRIPTION
Here are some updates that don't add new features, but should make maintaining the project and contributing to it that much easier:

# refactor(types): add explicit types
No runtime change, but maybe slightly easier to understand and maintain the code.

---

# chore: all development dependencies are locked and reliably installable
This is a change that builds on the base of the build system I worked on a few days ago. It adds the following improvements:
- the exact versions of all testing dependencies are stored within the project (previously they were outside).
  - the versions are stored in a  lock file. I used https://github.com/folke/lazy.nvim because it's the only modern one I know.
  - lazy.nvim is used both to install and maintain the dependencies, as well as loading them when it's time to test.

---

# feat(development): controlled playground nvim instance
This is a side effect of the previous one. The testing setup can also be used to launch a minimal nvim that can be used to try the plugin out.
- idea: in the future, it could be used to reproduce bugs or collaborate with developers

Here is a mini demo. In the demo, I first install dependencies (according to the lock file) and then run tests.

https://github.com/gsuuon/tshjkl.nvim/assets/300791/b534cc78-d3f6-48a5-91e8-8045fb7d7b69

---

# docs: contribution instructions
These are pretty basic but should cover the essentials.