### PR TITLE
Change `vim.treesitter.get_node` error handling

### DIFF
--- a/lua/tshjkl/trail.lua
+++ b/lua/tshjkl/trail.lua
@@ -20,6 +20,7 @@ local M = {}
 function M.start()
   local ok, start_node = pcall(vim.treesitter.get_node)
   if not ok then
+    vim.notify('Treesitter node not found', vim.log.levels.ERROR)
     return
   end
 

--- a/lua/tshjkl/trail.lua
+++ b/lua/tshjkl/trail.lua
@@ -18,8 +18,8 @@ local M = {}
 
 ---@return Trail | nil
 function M.start()
-  local start_node = vim.treesitter.get_node()
-  if start_node == nil then
+  local ok, start_node = pcall(vim.treesitter.get_node)
+  if not ok then
     return
   end
 


### PR DESCRIPTION
This pr suppresses treesitter errors.
vim.treesitter.get_node` throws an error instead of returning nil if the parser is not found. (e.g. ft=text)

<img width="1746" alt="image" src="https://github.com/gsuuon/tshjkl.nvim/assets/15827817/0bbb5044-094b-45cd-ab8f-bdc3c5a3b308">

This PR respects the current implementation approach.
Another approach I am considering is to add error handling.

https://github.com/ttak0422/tshjkl.nvim/blob/4ad8122065c5732356b69f7b265401a4b82b9709/lua/tshjkl/trail.lua#L24-L28

If this is your preference, close this PR and create a new one.

Thank you.
