### PR TITLE
feat: node-wise visual mode (multiselect)

### DIFF
--- a/lua/tshjkl/init.lua
+++ b/lua/tshjkl/init.lua
@@ -205,18 +205,18 @@ do
   }
 end
 
----@param a NodePosition
----@param b NodePosition
-local function join_positions(a, b)
-  ---@param a Point
-  ---@param b Point
-  local function compare(a, b)
-    if a.row ~= b.row then
-      return a.row < b.row
+---@param posA NodePosition
+---@param posB NodePosition
+local function join_positions(posA, posB)
+  ---@param pointA Point
+  ---@param pointB Point
+  local function compare(pointA, pointB)
+    if pointA.row ~= pointB.row then
+      return pointA.row < pointB.row
     end
 
-    if a.col ~= b.col then
-      return a.col < b.col
+    if pointA.col ~= pointB.col then
+      return pointA.col < pointB.col
     end
 
     return false
@@ -225,10 +225,10 @@ local function join_positions(a, b)
   local earliest_first
   do
     local positions = {
-      a.start,
-      a.stop,
-      b.start,
-      b.stop,
+      posA.start,
+      posA.stop,
+      posB.start,
+      posB.stop,
     }
 
     table.sort(positions, compare)
@@ -370,7 +370,8 @@ local function keybind(t, binds)
 
   local function nodewise_visual()
     if M.nodewise_start_position then
-      exit()
+      M.nodewise_start_position = nil
+      set_current_node(M.current_node) -- redraw
     else
       local n = t.current()
       M.nodewise_start_position = node_position(n)

--- a/readme.md
+++ b/readme.md
@@ -105,9 +105,9 @@ use {
 The default options will visual select the current node - since the visual highlight will render over other highlights, you won't see the child extmarks. If you prefer to see those, set `select_current_node = false` and use the `v` keybind in ts-mode to manually select the current node instead.
 
 ## Keymaps
-Check [binds](https://github.com/gsuuon/tshjkl.nvim/blob/9c608e4a70c69a4ab0e01f22a2f507106491c4af/lua/tshjkl/init.lua#L326) for more
+These keymaps are added when `tshjkl` is toggled on. Check [binds](./lua/tshjkl/init.lua#L437) for more.
 
-`v` — visual select the current node (if `config.select_current_node` is false)  
+`v` — enter node-wise visual mode if `select_current_node` is true, else visual select the current node  
 `b` — visual select backwards  
 
 `h` — parent  
@@ -121,7 +121,7 @@ Check [binds](https://github.com/gsuuon/tshjkl.nvim/blob/9c608e4a70c69a4ab0e01f2
 `L` — inner-most child  
 
 ### Binds
-You can bind additional keys for 'tshjkl' mode with the `binds` option. This takes a function of which takes `bind` and `tshjkl` - bind lets you bind additional keys, and tshjkl exposes `tshjkl.current_node()`, `tshjkl.set_node()` and `tshjkl.exit()`. Pass `true` to `tshjkl.exit` to drop to normal mode (if `select_current_node` is true).
+You can bind additional keys for 'tshjkl' mode with the `binds` option. This takes a function which takes `bind` and `tshjkl` - bind lets you bind additional keys, and tshjkl exposes `tshjkl.current_node()`, `tshjkl.set_node()` and `tshjkl.exit()`. Pass `true` to `tshjkl.exit` to drop to normal mode (if `select_current_node` is true).
 
 You can also add binds per buffer by setting `vim.b.tshjkl_binds`, for example in `ftplugin/lua.lua`:
 ```lua


### PR DESCRIPTION
Resolves #17 

It works just like visual mode but nodewise, including parent/child navigation. Toggle into  tshjkl then press 'v' again to enter nodewise visual mode

https://github.com/gsuuon/tshjkl.nvim/assets/6422188/dcfd7cd0-9a40-4105-85d3-aa2b82808022


